### PR TITLE
Add docker image for MySQL 5.6.29

### DIFF
--- a/servers/database/mysql/centos/Dockerfile
+++ b/servers/database/mysql/centos/Dockerfile
@@ -1,0 +1,53 @@
+FROM repositoryjp/centos:6.6
+MAINTAINER Shinya Kinoshita <skinoshita@repositories.jp>
+
+LABEL name="MySQL Server Image" \
+      description="The image for creating docker container of MySQL Server." \
+      distribution="centos" \
+      centos-version="6.6" \
+      mysql-version="5.6.29" \
+      vendor="REPOSITORY <http://www.repositories.jp>" \
+      license="MIT"
+
+ENV MYSQL_VERSION 5.6.29
+
+USER root
+WORKDIR /tmp
+
+# Create mysql user.
+RUN groupadd -r mysql && useradd -r -g mysql mysql
+
+# Install necessary packages.
+RUN yum install -y libtool \
+                   libaio \
+                   libaio-devel \
+                   zlib-devel \
+                   numactl
+
+# Install mysql.
+RUN wget https://dev.mysql.com/get/Downloads/MySQL-5.6/MySQL-client-${MYSQL_VERSION}-1.el6.x86_64.rpm && \
+    rpm -U MySQL-client-${MYSQL_VERSION}-1.el6.x86_64.rpm && \
+    wget https://dev.mysql.com/get/Downloads/MySQL-5.6/MySQL-server-${MYSQL_VERSION}-1.el6.x86_64.rpm && \
+    rpm -U MySQL-server-${MYSQL_VERSION}-1.el6.x86_64.rpm && \
+    wget https://dev.mysql.com/get/Downloads/MySQL-5.6/MySQL-devel-${MYSQL_VERSION}-1.el6.x86_64.rpm && \
+    rpm -U MySQL-devel-${MYSQL_VERSION}-1.el6.x86_64.rpm && \
+    wget https://dev.mysql.com/get/Downloads/MySQL-5.6/MySQL-shared-compat-${MYSQL_VERSION}-1.el6.x86_64.rpm && \
+    rpm -U MySQL-shared-compat-${MYSQL_VERSION}-1.el6.x86_64.rpm && \
+    wget https://dev.mysql.com/get/Downloads/Connector-Python/mysql-connector-python-2.1.3-1.el6.x86_64.rpm && \
+    rpm -U mysql-connector-python-2.1.3-1.el6.x86_64.rpm && \
+    wget https://dev.mysql.com/get/Downloads/MySQLGUITools/mysql-utilities-1.5.6-1.el6.noarch.rpm && \
+    rpm -U mysql-utilities-1.5.6-1.el6.noarch.rpm && \
+    rm -rf
+
+COPY etc/my.cnf /etc/my.cnf
+RUN chmod 644 /etc/my.cnf
+
+# Configure container.
+USER root
+WORKDIR /root
+
+EXPOSE 3306
+
+VOLUME /var/lib/mysql
+
+CMD ["/usr/bin/mysqld_safe"]

--- a/servers/database/mysql/centos/README.md
+++ b/servers/database/mysql/centos/README.md
@@ -1,0 +1,39 @@
+# The Recipe of MySQL Docker Image
+
+This directory contains Dockerfile of [MySQL](https://www.mysql.com/) for [Docker](https://www.docker.com/)'s automated build published to the public [Docker Hub Registry](https://hub.docker.com/).
+
+## Base Docker Image
+
+[repositoryjp/centos:6.6](https://hub.docker.com/r/repositoryjp/centos/)
+
+
+## MySQL Version
+
+5.6.29
+
+## Installation
+
+[1] Install [Docker](https://www.docker.com/).
+
+[2] Download automated build from public [Docker Hub Registry](https://hub.docker.com/): `docker pull repositoryjp/mysql`
+
+## Usage
+
+```
+docker run -d -p (host's port for mysql):3306 -v (host's path for mysql's data directory):/var/lib/mysql repositoryjp/mysql
+```
+
+[options]
+
+* Port number for mysql (required) : -p (host's port for mysql):3306
+* Data directory path (optional) : -v (host's path for mysql's data directory):/var/lib/mysql
+
+
+## License
+
+See the file [LICENSE](../../../../LICENSE).
+
+## Author
+
+[Shinya Kinoshita](http://www.shinyakinoshita.com) ( [REPOSITORY](http://www.repositories.jp) )
+

--- a/servers/database/mysql/centos/etc/my.cnf
+++ b/servers/database/mysql/centos/etc/my.cnf
@@ -1,0 +1,17 @@
+[client]
+port=3306
+socket=/var/lib/mysql/mysql.sock
+
+[mysqld]
+datadir=/var/lib/mysql
+socket=/var/lib/mysql/mysql.sock
+user=mysql
+symbolic-links=0
+
+general_log=1
+general_log_file=/var/lib/mysql/query.log
+
+[mysqld_safe]
+log-error=/var/log/mysqld.log
+socket=/var/lib/mysql/mysql.sock
+pid-file=/var/lib/mysql/mysql.pid


### PR DESCRIPTION
Build a docker image for MySQL 5.6.29 based on this image
(https://hub.docker.com/r/repositoryjp/centos/).