### PR TITLE
Add docker image for PHP 5.6.20

### DIFF
--- a/applications/php-5.6.20/centos/Dockerfile
+++ b/applications/php-5.6.20/centos/Dockerfile
@@ -1,0 +1,30 @@
+FROM repositoryjp/virtphp
+MAINTAINER Shinya Kinoshita <skinoshita@repositories.jp>
+
+LABEL name="PHP 5.6.20 Image" \
+      description="The image for creating docker container of PHP 5.6.20 Environment." \
+      distribution="centos" \
+      centos-version="6.6" \
+      php-version="5.6.20" \
+      vendor="REPOSIORY <http://www.repositories.jp>" \
+      license="MIT"
+
+ENV PHP_VERSION 5.6.20
+
+USER root
+
+# Install PHP 5.6.20
+RUN phpbrew install ${PHP_VERSION} +default +everything -- --with-icu-dir=/usr --with-gd --with-jpeg-dir=/usr/lib64 --with-png-dir=/usr/png --enable-gd-jis-conv
+RUN phpbrew switch ${PHP_VERSION}
+
+RUN virtphp create --php-bin-dir=$HOME/.phpbrew/php/php-${PHP_VERSION}/bin phpenv
+
+RUN sed -e 's/;date.timezone =/date.timezone = UTC/g' $HOME/.virtphp/envs/phpenv/etc/php.ini > /tmp/php.ini
+RUN mv -f /tmp/php.ini .virtphp/envs/phpenv/etc/php.ini
+RUN echo "[[ -e ~/.virtphp/envs/phpenv/ ]] && source ~/.virtphp/envs/phpenv/bin/activate" >> ~/.bashrc
+
+# Configure container.
+USER root
+WORKDIR /root
+
+CMD ["/usr/sbin/sshd", "-D"]

--- a/applications/php-5.6.20/centos/README.md
+++ b/applications/php-5.6.20/centos/README.md
@@ -1,0 +1,31 @@
+# The Recipe of PHP 5.6.20 Docker Image
+
+This directory contains Dockerfile of [PHP](http://php.net/) 5.6.20 for [Docker](https://www.docker.com/)'s automated build published to the public [Docker Hub Registry](https://hub.docker.com/).
+
+## Base Docker Image
+
+[repositoryjp/virtphp](https://hub.docker.com/r/repositoryjp/virtphp/)
+
+## PHP Version
+
+5.6.20
+
+## Installation
+
+[1] Install [Docker](https://www.docker.com/).
+
+[2] Download automated build from public [Docker Hub Registry](https://hub.docker.com/): `docker pull repositoryjp/php-5.6.20`
+
+## Usage
+
+```
+docker run -i -t -d -P repositoryjp/php-5.6.20
+```
+
+## License
+
+See the file [LICENSE](../../../LICENSE).
+
+## Author
+
+[Shinya Kinoshita](http://www.shinyakinoshita.com) ( [REPOSITORY](http://www.repositories.jp) )


### PR DESCRIPTION
Build a docker image for PHP 5.6.20 based on this image
(https://hub.docker.com/r/repositoryjp/virtphp/).