### PR TITLE
Add docker image for PHP 5.6.21

### DIFF
--- a/applications/php/5.6.21/centos/6.6/Dockerfile
+++ b/applications/php/5.6.21/centos/6.6/Dockerfile
@@ -1,0 +1,26 @@
+FROM repositoryjp/phpbrew-1.21.3:centos-6.6
+MAINTAINER Shinya Kinoshita <skinoshita@repositories.jp>
+
+LABEL name="PHP 5.6.21 Image" \
+      description="The image for creating docker container of PHP 5.6.21 Environment." \
+      distribution="centos" \
+      centos-version="6.6" \
+      php-version="5.6.21" \
+      vendor="REPOSIORY <http://www.repositories.jp>" \
+      license="MIT"
+
+ENV PHP_VERSION 5.6.21
+
+USER root
+
+# Install PHP 5.6.21
+RUN phpbrew install ${PHP_VERSION} +default +everything -- --with-icu-dir=/usr --with-gd --with-jpeg-dir=/usr/lib64 --with-png-dir=/usr/png --enable-gd-jis-conv && \
+    sed -e 's/;date.timezone =/date.timezone = UTC/g' $HOME/.phpbrew/php/php-${PHP_VERSION}/etc/php.ini > /tmp/php.ini && \
+    mv -f /tmp/php.ini $HOME/.phpbrew/php/php-${PHP_VERSION}/etc/php.ini && \
+    echo "[[ -d ~/.phpbrew/php/php-5.6.21 ]] && phpbrew switch php-5.6.21" >> ~/.bashrc
+
+# Configure container.
+USER root
+WORKDIR /root
+
+CMD ["/usr/sbin/sshd", "-D"]

--- a/applications/php/5.6.21/centos/6.6/README.md
+++ b/applications/php/5.6.21/centos/6.6/README.md
@@ -1,0 +1,27 @@
+# The Recipe of PHP 5.6.21 Docker Image
+
+This directory contains Dockerfile of [PHP](http://php.net/) 5.6.21 for [Docker](https://www.docker.com/)'s automated build published to the public [Docker Hub Registry](https://hub.docker.com/).
+
+## Base Docker Image
+
+[repositoryjp/phpbrew-1.21.3:centos-6.6](https://hub.docker.com/r/repositoryjp/phpbrew-1.21.3/)
+
+## Installation
+
+[1] Install [Docker](https://www.docker.com/).
+
+[2] Download automated build from public [Docker Hub Registry](https://hub.docker.com/): `docker pull repositoryjp/php-5.6.21`
+
+## Usage
+
+```
+docker run -i -t -d -P repositoryjp/php-5.6.21
+```
+
+## License
+
+See the file [LICENSE](../../../../../LICENSE).
+
+## Author
+
+[Shinya Kinoshita](http://www.shinyakinoshita.com) ( [REPOSITORY](http://www.repositories.jp) )

--- a/applications/php/README.md
+++ b/applications/php/README.md
@@ -5,6 +5,7 @@
 This direcotry contains recipes about below versions of PHP.
 
 * 5.6.20
+* 5.6.21
 
 ## License
 


### PR DESCRIPTION
Build a docker image for PHP 5.6.21 based on this image
(https://hub.docker.com/r/repositoryjp/phpbrew-1.21.3/).