### PR TITLE
Add docker image for Nginx 1.8.1 built on Centos 6.6 and 6.7

### DIFF
--- a/servers/web/nginx/1.8.1/centos/6.6/Dockerfile
+++ b/servers/web/nginx/1.8.1/centos/6.6/Dockerfile
@@ -1,0 +1,29 @@
+FROM repositoryjp/centos:6.6
+MAINTAINER Shinya Kinoshita <skinoshita@repositories.jp>
+
+LABEL name="Nginx 1.8.1 Image" \
+      description="The image for creating docker container of Nginx 1.8.1 Server." \
+      distribution="centos" \
+      centos-version="6.6" \
+      nginx-version="1.8.1" \
+      vendor="REPOSITORY <http://www.repositories.jp>" \
+      license="MIT"
+
+ENV NGINX_VERSION 1.8.1
+
+USER root
+WORKDIR /tmp
+
+# Install Nginx.
+RUN wget http://nginx.org/packages/centos/6/x86_64/RPMS/nginx-${NGINX_VERSION}-1.el6.ngx.x86_64.rpm && \
+    rpm -U nginx-${NGINX_VERSION}-1.el6.ngx.x86_64.rpm
+COPY etc/nginx/nginx.conf /etc/nginx/nginx.conf
+
+# Configure container.
+EXPOSE 80 443
+VOLUME /etc/nginx/conf.d /usr/share/nginx /var/log/nginx
+
+USER root
+WORKDIR /root
+
+CMD ["/usr/sbin/nginx", "-g", "daemon off;"]

--- a/servers/web/nginx/1.8.1/centos/6.6/README.md
+++ b/servers/web/nginx/1.8.1/centos/6.6/README.md
@@ -1,0 +1,35 @@
+# The Recipe of Nginx 1.8.1 Docker Image
+
+This directory contains Dockerfile of [Nginx](http://nginx.org/en/) 1.8.1 for [Docker](https://www.docker.com/)'s automated build published to the public [Docker Hub Registry](https://hub.docker.com/).
+
+## Base Docker Image
+
+[repositoryjp/centos:6.6](https://hub.docker.com/r/repositoryjp/centos/)
+
+## Installation
+
+[1] Install [Docker](https://www.docker.com/).
+
+[2] Download automated build from public [Docker Hub Registry](https://hub.docker.com/): `docker pull repositoryjp/nginx-1.8.1:centos-6.6`
+
+## Usage
+
+```
+docker run -d -p (host's port for http):80 -p (host's port for https):443 -v (host's path for nginx configuration):/etc/nginx/conf.d/ -v (host's path for document root):/usr/share/nginx/ -v (host's path for logfile):/var/log/nginx repositoryjp/nginx-1.8.0:centos-6.6
+```
+
+[options]
+
+* Port number for http (required) : -p (host's port for http):80
+* Port number for https (optional) : -p (host's port for https):443
+* Nginx configuration path (optional) : -v (host's path for nginx configuration):/etc/nginx/conf.d/
+* Document root path (optional) : -v (host's path for document root):/usr/share/nginx/
+* Logfile path (optional) : -v (host's path for logfile):/var/log/nginx repositoryjp/nginx
+
+## License
+
+See the file [LICENSE](../../../../../LICENSE).
+
+## Author
+
+[Shinya Kinoshita](http://www.shinyakinoshita.com) ( [REPOSITORY](http://www.repositories.jp) )

--- a/servers/web/nginx/1.8.1/centos/6.6/etc/nginx/nginx.conf
+++ b/servers/web/nginx/1.8.1/centos/6.6/etc/nginx/nginx.conf
@@ -1,0 +1,29 @@
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/servers/web/nginx/1.8.1/centos/6.7/Dockerfile
+++ b/servers/web/nginx/1.8.1/centos/6.7/Dockerfile
@@ -1,0 +1,29 @@
+FROM repositoryjp/centos:6.7
+MAINTAINER Shinya Kinoshita <skinoshita@repositories.jp>
+
+LABEL name="Nginx 1.8.1 Image" \
+      description="The image for creating docker container of Nginx 1.8.1 Server." \
+      distribution="centos" \
+      centos-version="6.7" \
+      nginx-version="1.8.1" \
+      vendor="REPOSITORY <http://www.repositories.jp>" \
+      license="MIT"
+
+ENV NGINX_VERSION 1.8.1
+
+USER root
+WORKDIR /tmp
+
+# Install Nginx.
+RUN wget http://nginx.org/packages/centos/6/x86_64/RPMS/nginx-${NGINX_VERSION}-1.el6.ngx.x86_64.rpm && \
+    rpm -U nginx-${NGINX_VERSION}-1.el6.ngx.x86_64.rpm
+COPY etc/nginx/nginx.conf /etc/nginx/nginx.conf
+
+# Configure container.
+EXPOSE 80 443
+VOLUME /etc/nginx/conf.d /usr/share/nginx /var/log/nginx
+
+USER root
+WORKDIR /root
+
+CMD ["/usr/sbin/nginx", "-g", "daemon off;"]

--- a/servers/web/nginx/1.8.1/centos/6.7/README.md
+++ b/servers/web/nginx/1.8.1/centos/6.7/README.md
@@ -1,0 +1,35 @@
+# The Recipe of Nginx 1.8.1 Docker Image
+
+This directory contains Dockerfile of [Nginx](http://nginx.org/en/) 1.8.1 for [Docker](https://www.docker.com/)'s automated build published to the public [Docker Hub Registry](https://hub.docker.com/).
+
+## Base Docker Image
+
+[repositoryjp/centos:6.7](https://hub.docker.com/r/repositoryjp/centos/)
+
+## Installation
+
+[1] Install [Docker](https://www.docker.com/).
+
+[2] Download automated build from public [Docker Hub Registry](https://hub.docker.com/): `docker pull repositoryjp/nginx-1.8.1:centos-6.7`
+
+## Usage
+
+```
+docker run -d -p (host's port for http):80 -p (host's port for https):443 -v (host's path for nginx configuration):/etc/nginx/conf.d/ -v (host's path for document root):/usr/share/nginx/ -v (host's path for logfile):/var/log/nginx repositoryjp/nginx
+```
+
+[options]
+
+* Port number for http (required) : -p (host's port for http):80
+* Port number for https (optional) : -p (host's port for https):443
+* Nginx configuration path (optional) : -v (host's path for nginx configuration):/etc/nginx/conf.d/
+* Document root path (optional) : -v (host's path for document root):/usr/share/nginx/
+* Logfile path (optional) : -v (host's path for logfile):/var/log/nginx repositoryjp/nginx
+
+## License
+
+See the file [LICENSE](../../../../../LICENSE).
+
+## Author
+
+[Shinya Kinoshita](http://www.shinyakinoshita.com) ( [REPOSITORY](http://www.repositories.jp) )

--- a/servers/web/nginx/1.8.1/centos/6.7/etc/nginx/nginx.conf
+++ b/servers/web/nginx/1.8.1/centos/6.7/etc/nginx/nginx.conf
@@ -1,0 +1,29 @@
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/servers/web/nginx/README.md
+++ b/servers/web/nginx/README.md
@@ -5,6 +5,7 @@
 This direcotry contains recipes about below versions of Nginx.
 
 * 1.8.0
+* 1.8.1
 
 ## License
 


### PR DESCRIPTION
Build a docker image for Nginx 1.8.1 based on this image
(https://hub.docker.com/r/repositoryjp/centos/).