### PR TITLE
Add docker image for MySQL 5.6.29 built on CentOS 6.7

### DIFF
--- a/servers/database/mysql/5.6.29/centos/6.7/Dockerfile
+++ b/servers/database/mysql/5.6.29/centos/6.7/Dockerfile
@@ -1,0 +1,53 @@
+FROM repositoryjp/centos:6.7
+MAINTAINER Shinya Kinoshita <skinoshita@repositories.jp>
+
+LABEL name="MySQL 5.6.29 Server Image" \
+      description="The image for creating docker container of MySQL 5.6.29 Server." \
+      distribution="centos" \
+      centos-version="6.7" \
+      mysql-version="5.6.29" \
+      vendor="REPOSITORY <http://www.repositories.jp>" \
+      license="MIT"
+
+ENV MYSQL_VERSION 5.6.29
+
+USER root
+WORKDIR /tmp
+
+# Create mysql user.
+RUN groupadd -r mysql && useradd -r -g mysql mysql
+
+# Install necessary packages.
+RUN yum install -y libtool \
+                   libaio \
+                   libaio-devel \
+                   zlib-devel \
+                   numactl
+
+# Install MySQL.
+RUN wget https://dev.mysql.com/get/Downloads/MySQL-5.6/MySQL-client-${MYSQL_VERSION}-1.el6.x86_64.rpm && \
+    rpm -U MySQL-client-${MYSQL_VERSION}-1.el6.x86_64.rpm && \
+    wget https://dev.mysql.com/get/Downloads/MySQL-5.6/MySQL-server-${MYSQL_VERSION}-1.el6.x86_64.rpm && \
+    rpm -U MySQL-server-${MYSQL_VERSION}-1.el6.x86_64.rpm && \
+    wget https://dev.mysql.com/get/Downloads/MySQL-5.6/MySQL-devel-${MYSQL_VERSION}-1.el6.x86_64.rpm && \
+    rpm -U MySQL-devel-${MYSQL_VERSION}-1.el6.x86_64.rpm && \
+    wget https://dev.mysql.com/get/Downloads/MySQL-5.6/MySQL-shared-compat-${MYSQL_VERSION}-1.el6.x86_64.rpm && \
+    rpm -U MySQL-shared-compat-${MYSQL_VERSION}-1.el6.x86_64.rpm && \
+    wget https://dev.mysql.com/get/Downloads/Connector-Python/mysql-connector-python-2.1.3-1.el6.x86_64.rpm && \
+    rpm -U mysql-connector-python-2.1.3-1.el6.x86_64.rpm && \
+    wget https://dev.mysql.com/get/Downloads/MySQLGUITools/mysql-utilities-1.5.6-1.el6.noarch.rpm && \
+    rpm -U mysql-utilities-1.5.6-1.el6.noarch.rpm && \
+    rm -rf
+
+COPY etc/my.cnf /etc/my.cnf
+RUN chmod 644 /etc/my.cnf
+
+# Configure container.
+USER root
+WORKDIR /root
+
+EXPOSE 3306
+
+VOLUME /var/lib/mysql
+
+CMD ["/usr/bin/mysqld_safe"]

--- a/servers/database/mysql/5.6.29/centos/6.7/README.md
+++ b/servers/database/mysql/5.6.29/centos/6.7/README.md
@@ -4,18 +4,18 @@ This directory contains Dockerfile of [MySQL](https://www.mysql.com/) 5.6.29 for
 
 ## Base Docker Image
 
-[repositoryjp/centos:6.6](https://hub.docker.com/r/repositoryjp/centos/)
+[repositoryjp/centos:6.7](https://hub.docker.com/r/repositoryjp/centos/)
 
 ## Installation
 
 [1] Install [Docker](https://www.docker.com/).
 
-[2] Download automated build from public [Docker Hub Registry](https://hub.docker.com/): `docker pull repositoryjp/mysql-5.6.29:centos-6.6`
+[2] Download automated build from public [Docker Hub Registry](https://hub.docker.com/): `docker pull repositoryjp/mysql-5.6.29:centos-6.7`
 
 ## Usage
 
 ```
-docker run -d -p (host's port for mysql):3306 -v (host's path for mysql's data directory):/var/lib/mysql repositoryjp/mysql-5.6.29:centos-6.6
+docker run -d -p (host's port for mysql):3306 -v (host's path for mysql's data directory):/var/lib/mysql repositoryjp/mysql-5.6.29:centos-6.7
 ```
 
 [options]

--- a/servers/database/mysql/5.6.29/centos/6.7/etc/my.cnf
+++ b/servers/database/mysql/5.6.29/centos/6.7/etc/my.cnf
@@ -1,0 +1,17 @@
+[client]
+port=3306
+socket=/var/lib/mysql/mysql.sock
+
+[mysqld]
+datadir=/var/lib/mysql
+socket=/var/lib/mysql/mysql.sock
+user=mysql
+symbolic-links=0
+
+general_log=1
+general_log_file=/var/lib/mysql/query.log
+
+[mysqld_safe]
+log-error=/var/log/mysqld.log
+socket=/var/lib/mysql/mysql.sock
+pid-file=/var/lib/mysql/mysql.pid


### PR DESCRIPTION
Build a docker image for MySQL 5.6.29 based on this image
(https://hub.docker.com/r/repositoryjp/centos/).