### PR TITLE
Add docker image for pyenv v20160422 built on Centos 6.6 and 6.7

### DIFF
--- a/applications/pyenv/v20160422/centos/6.6/Dockerfile
+++ b/applications/pyenv/v20160422/centos/6.6/Dockerfile
@@ -1,0 +1,38 @@
+FROM repositoryjp/centos:6.6
+MAINTAINER Shinya Kinoshita <skinoshita@repositories.jp>
+
+LABEL name="Python Version Management (pyenv) v20160422 Image" \
+      description="The image for creating docker container of Python Version Management (pyenv) v20160422." \
+      distribution="centos" \
+      centos-version="6.6" \
+      pyenv-version="v20160422" \
+      vendor="REPOSITORY <http://www.repositories.jp>" \
+      license="MIT"
+
+ENV pyenv_version 20160422
+
+USER root
+WORKDIR /usr/local/src
+
+# Install necessary packages.
+RUN yum install -y readline-devel \
+                   zlib-devel \
+                   openssl-devel \
+                   sqlite-devel
+
+# Install pyenv.
+RUN wget https://github.com/yyuu/pyenv/archive/v${pyenv_version}.tar.gz && \
+    tar xvzf v${pyenv_version}.tar.gz && \
+    mv pyenv-${pyenv_version} pyenv && \
+    rm -f v${pyenv_version}.tar.gz && \
+    echo 'export PYENV_ROOT="/usr/local/src/pyenv"' >> /etc/profile.d/pyenv.sh && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> /etc/profile.d/pyenv.sh && \
+    echo 'eval "$(pyenv init -)"' >> /etc/profile.d/pyenv.sh && \
+    exec $SHELL -l && \
+    pyenv --version
+
+# Configure container
+USER root
+WORKDIR /root
+
+CMD ["/usr/sbin/sshd", "-D"]

--- a/applications/pyenv/v20160422/centos/6.6/README.md
+++ b/applications/pyenv/v20160422/centos/6.6/README.md
@@ -1,0 +1,41 @@
+# The Recipe of Python Version Management (pyenv) v20160422
+
+This repository contains Dockerfile of [pyenv](https://github.com/yyuu/pyenv) for [Docker](https://www.docker.com/)'s automated build published to the public [Docker Hub Registry](https://hub.docker.com/).
+
+## Base Docker Image
+
+* [repositoryjp/centos:6.6](https://hub.docker.com/r/repositoryjp/centos/)
+
+## How to install Python
+
+If you want to use Python, run below commands to install Python that you want.
+
+[1] Confirm installable versions by pyenv.
+
+	pyenv install --list
+
+[2] Install Python from pyenv.
+
+	# Example:
+	#
+	# Install Python 2.7.11
+	#
+	pyenv install 2.7.11
+
+## Installation
+
+1. Install [Docker](https://www.docker.com/).
+
+2. Download automated build from public [Docker Hub Registry](https://hub.docker.com/): `docker pull repositoryjp/pyenv-v20160422:cento-6.6`
+
+## Usage
+
+    docker run -i -t -d -P repositoryjp/pyenv-v20160422:cento-6.6
+
+## License
+
+See the file [LICENSE](../../../../../LICENSE).
+
+## Author
+
+[Shinya Kinoshita](http://www.shinyakinoshita.com) ( [REPOSITORY](http://www.repositories.jp) )

--- a/applications/pyenv/v20160422/centos/6.7/Dockerfile
+++ b/applications/pyenv/v20160422/centos/6.7/Dockerfile
@@ -1,0 +1,38 @@
+FROM repositoryjp/centos:6.7
+MAINTAINER Shinya Kinoshita <skinoshita@repositories.jp>
+
+LABEL name="Python Version Management (pyenv) v20160422 Image" \
+      description="The image for creating docker container of Python Version Management (pyenv) v20160422." \
+      distribution="centos" \
+      centos-version="6.7" \
+      pyenv-version="v20160422" \
+      vendor="REPOSITORY <http://www.repositories.jp>" \
+      license="MIT"
+
+ENV pyenv_version 20160422
+
+USER root
+WORKDIR /usr/local/src
+
+# Install necessary packages.
+RUN yum install -y readline-devel \
+                   zlib-devel \
+                   openssl-devel \
+                   sqlite-devel
+
+# Install pyenv.
+RUN wget https://github.com/yyuu/pyenv/archive/v${pyenv_version}.tar.gz && \
+    tar xvzf v${pyenv_version}.tar.gz && \
+    mv pyenv-${pyenv_version} pyenv && \
+    rm -f v${pyenv_version}.tar.gz && \
+    echo 'export PYENV_ROOT="/usr/local/src/pyenv"' >> /etc/profile.d/pyenv.sh && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> /etc/profile.d/pyenv.sh && \
+    echo 'eval "$(pyenv init -)"' >> /etc/profile.d/pyenv.sh && \
+    exec $SHELL -l && \
+    pyenv --version
+
+# Configure container
+USER root
+WORKDIR /root
+
+CMD ["/usr/sbin/sshd", "-D"]

--- a/applications/pyenv/v20160422/centos/6.7/README.md
+++ b/applications/pyenv/v20160422/centos/6.7/README.md
@@ -1,0 +1,41 @@
+# The Recipe of Python Version Management (pyenv) v20160422
+
+This repository contains Dockerfile of [pyenv](https://github.com/yyuu/pyenv) for [Docker](https://www.docker.com/)'s automated build published to the public [Docker Hub Registry](https://hub.docker.com/).
+
+## Base Docker Image
+
+* [repositoryjp/centos:6.7](https://hub.docker.com/r/repositoryjp/centos/)
+
+## How to install Python
+
+If you want to use Python, run below commands to install Python that you want.
+
+[1] Confirm installable versions by pyenv.
+
+	pyenv install --list
+
+[2] Install Python from pyenv.
+
+	# Example:
+	#
+	# Install Python 2.7.11
+	#
+	pyenv install 2.7.11
+
+## Installation
+
+1. Install [Docker](https://www.docker.com/).
+
+2. Download automated build from public [Docker Hub Registry](https://hub.docker.com/): `docker pull repositoryjp/pyenv-v20160422:cento-6.7`
+
+## Usage
+
+    docker run -i -t -d -P repositoryjp/pyenv-v20160422:cento-6.7
+
+## License
+
+See the file [LICENSE](../../../../../LICENSE).
+
+## Author
+
+[Shinya Kinoshita](http://www.shinyakinoshita.com) ( [REPOSITORY](http://www.repositories.jp) )


### PR DESCRIPTION
Build a docker image for pyenv v20160422 based on this image
(https://hub.docker.com/r/repositoryjp/centos/).